### PR TITLE
Initial 'dark-mode' test-setup script (POC) for bug 1511350

### DIFF
--- a/scripts/blackbg.sh
+++ b/scripts/blackbg.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# The following "test" is directly from https://bugzilla.mozilla.org/show_bug.cgi?id=1511350#c0:
+
+adb shell am start -n org.mozilla.firefox/.App -a android.intent.action.VIEW -d "'data:text/html;base64,PGJvZHkgc3R5bGU9ImJhY2tncm91bmQtY29sb3I6YmxhY2siPg=='" --ez showstartpane false


### PR DESCRIPTION
Sorry, forgot to git checkout -b this one, but it's here, it works, is minimal, yada yada!

This starts to address the test-case _setup_ for our "dark-mode" proxy, but more importantly also paves the way across browsers, easily, so we can soon integrate with our various tooling (shell and Raptor, etc.): https://bugzilla.mozilla.org/show_bug.cgi?id=1511350#c0